### PR TITLE
Fix broken links

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,9 +47,9 @@ lets you reach more people.
 You can also earn revenue
 or build Chrome-specific features into your app.
 For more information, read
-<a href="http://www.google.com/intl/en/landing/chrome/webstore/create/why-build-apps.html">why it makes sense for your business</a>
+<a href="https://developers.google.com/google-apps/marketplace/sell/why-build-apps">why it makes sense for your business</a>
 and
-<a href="http://www.google.com/intl/en/landing/chrome/webstore/create/success-stories.html">success stories</a>.
+<a href="https://developers.google.com/google-apps/marketplace/sell/success-stories">success stories</a>.
 </p>
 
 <h2>How do I start?</h2>


### PR DESCRIPTION
Fix 2 links that point to pages that have moved elsewhere. The whole "Why should i use the Chrome Web Store?" section needs to be cleaned up at some point, since the pages the links point to appear to be deprecated and broken.