### PR TITLE
Make download links over HTTPS

### DIFF
--- a/branding.html
+++ b/branding.html
@@ -83,7 +83,7 @@ for the badge.
       <li> <a href="images/ChromeWebStore_Badge_v2_206x58.png">small PNG</a> </li>
       <li> <a href="images/ChromeWebStore_Badge_v2_340x96.png">medium PNG</a> </li>
       <li> <a href="images/ChromeWebStore_Badge_v2_496x150.png">large PNG</a> </li>
-      <li> <a href="http://dl.google.com/code/chromewebstore/chromewebstore_badge_v2.zip">Adobe Illustrator</a> </li>
+      <li> <a href="https://dl.google.com/code/chromewebstore/chromewebstore_badge_v2.zip">Adobe Illustrator</a> </li>
       </ul>
     </td>
     <td>
@@ -91,7 +91,7 @@ for the badge.
       <li> <a href="images/ChromeWebStore_BadgeWBorder_v2_206x58.png">small PNG (with border)</a> </li>
       <li> <a href="images/ChromeWebStore_BadgeWBorder_v2_340x96.png">medium PNG (with border)</a> </li>
       <li> <a href="images/ChromeWebStore_BadgeWBorder_v2_496x150.png">large PNG (with border)</a> </li>
-      <li> <a href="http://dl.google.com/code/chromewebstore/chromewebstore_badgewborder_v2.zip">Adobe Illustrator (with border)</a> </li>
+      <li> <a href="https://dl.google.com/code/chromewebstore/chromewebstore_badgewborder_v2.zip">Adobe Illustrator (with border)</a> </li>
       </ul>
     </td>
   </tr>


### PR DESCRIPTION
Currently, the download links to dl.google.com are served over HTTP. This poses a security risk as these unencrypted downloads can be easily intercepted and made malicious. This commit fixes that issue.