### PR TITLE
Fix Chrome Apps warning and link to Google Groups

### DIFF
--- a/apps_vs_extensions.html
+++ b/apps_vs_extensions.html
@@ -2,10 +2,10 @@
 <p class="caution">
   <b>Important:</b>
   Chrome will be removing support for Chrome Apps on Windows, Mac, and
-  Linux.  Chrome OS will continue to support Chrome Apps.  Additionally,
+  Linux. Chrome OS will continue to support Chrome Apps. Additionally,
   Chrome and the Web Store will continue to support extensions on all
   platforms.
-  <a href="http://blog.chromium.org/2016/08/from-chrome-apps-to-web.html">
+  <a href="https://blog.chromium.org/2016/08/from-chrome-apps-to-web.html">
   Read the announcement</a> and learn more about
   <a href="https://developers.chrome.com/apps/migration">
   migrating your app</a>.
@@ -379,6 +379,6 @@ is key to building the best possible experience for your users.
 
 <p id="lastword">
 To learn more about installable web apps and ask questions to our team,
-you can visit our <a href="http://groups.google.com/a/chromium.org/group/chromium-apps/topics">discussion group</a>.
+you can visit our <a href="https://groups.google.com/a/chromium.org/group/chromium-apps/topics">discussion group</a>.
 </p>
 {{/partials.standard_store_article}}


### PR DESCRIPTION
Removed double spaces after period in the Chrome Apps warning, and made the link to Google Groups over HTTPS.