### PR TITLE
Fix Chrome Apps warning

### DIFF
--- a/about_webstore.html
+++ b/about_webstore.html
@@ -2,10 +2,10 @@
 <p class="caution">
   <b>Important:</b>
   Chrome will be removing support for Chrome Apps on Windows, Mac, and
-  Linux.  Chrome OS will continue to support Chrome Apps.  Additionally,
+  Linux. Chrome OS will continue to support Chrome Apps. Additionally,
   Chrome and the Web Store will continue to support extensions on all
   platforms.
-  <a href="http://blog.chromium.org/2016/08/from-chrome-apps-to-web.html">
+  <a href="https://blog.chromium.org/2016/08/from-chrome-apps-to-web.html">
   Read the announcement</a> and learn more about
   <a href="https://developers.chrome.com/apps/migration">
   migrating your app</a>.


### PR DESCRIPTION
Removed double spacing after period in Chrome Apps warning, and made its link to the Chromium blog over HTTPS.