### PR TITLE
Update Github link example for Trial example. Was 404ing

### DIFF
--- a/one_time_payments.html
+++ b/one_time_payments.html
@@ -434,7 +434,7 @@ if (license.result &amp;&amp; license.accessLevel == "FULL") {
 
 <ul>
     <li>
-        <a href="https://github.com/GoogleChrome/chrome-app-samples/tree/master/one-time-payment">
+        <a href="https://github.com/GoogleChrome/chrome-app-samples/tree/master/samples/one-time-payment">
             source code
         </a>
     </li>


### PR DESCRIPTION
The link for the source code for the javascript trial example was 404 as the folder was changed.

Before

<img width="1237" alt="screen shot 2018-06-05 at 11 59 38 pm" src="https://user-images.githubusercontent.com/6218780/41017863-996f84f8-691c-11e8-95ca-7d5b4bd87b15.png">


After


<img width="1237" alt="screen shot 2018-06-05 at 11 59 41 pm" src="https://user-images.githubusercontent.com/6218780/41017867-9eaf4f52-691c-11e8-87a2-6ad051b2202c.png">
