### PR TITLE
Developer Account Payment Clarification 

### DIFF
--- a/money.html
+++ b/money.html
@@ -39,6 +39,12 @@
     <strong>Note: </strong>Chrome Web Store payment methods are not available for hosted apps.
 </p>
 
+<p>
+  Items uploaded to the Web Store are unable to be purchased through the
+  same developer account.
+  Instead, use a trusted tester account to run through the purchase flow.  
+</p>
+
 <h2 id="inapp">In-app payments</h2>
 
 <p>

--- a/money.html
+++ b/money.html
@@ -42,7 +42,7 @@
 <p>
   Items uploaded to the Web Store are unable to be purchased through the
   same developer account.
-  Instead, use a trusted tester account to run through the purchase flow.  
+  Instead, use a trusted tester account to run a trial purchase flow.  
 </p>
 
 <h2 id="inapp">In-app payments</h2>


### PR DESCRIPTION
Per https://buganizer.corp.google.com/issues/79704145 . 

This adds clarification that developers are unable to purchase items uploaded to the Chrome Web Store from the same account used to upload said item. 